### PR TITLE
define missing variable name

### DIFF
--- a/docs/source/feature_detection.rst
+++ b/docs/source/feature_detection.rst
@@ -36,9 +36,10 @@ to find ``Features`` in MS data:
   ff.setLogType(LogType.CMD)
 
   # Run the feature finder
+  name = "centroided"
   features = FeatureMap() 
   seeds = FeatureMap()
-  params = FeatureFinder().getParameters("centroided")
+  params = FeatureFinder().getParameters(name)
   ff.run(name, input_map, features, params, seeds)
 
   features.setUniqueIds()


### PR DESCRIPTION
var name in the example was not defined!
set it to "centroided"