### PR TITLE
Added pandoc filters for a conversion with plain pandoc

### DIFF
--- a/docs/pandoc_filters/code_pandocfilter.py
+++ b/docs/pandoc_filters/code_pandocfilter.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+"""
+Pandoc filter to convert code blocks of certain language classes to code class
+"""
+
+from pandocfilters import *
+
+def addCodeClass(key, value, format, meta):
+  if key == 'CodeBlock':
+    [[ident, classes, keyvals], code] = value
+    if "python" in classes:
+      classes.remove("python")
+      classes.append("code")
+    return CodeBlock([ident, classes, keyvals], code)
+
+if __name__ == "__main__":
+  toJSONFilter(addCodeClass)

--- a/docs/pandoc_filters/ignore_pandocfilter.py
+++ b/docs/pandoc_filters/ignore_pandocfilter.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+
+"""
+Pandoc filter to ignore elements when having class ignore:
+e.g.
+.. code-block:: python
+    :class: ignore
+
+    print("Foo")
+"""
+
+from pandocfilters import *
+
+def ignore(key, value, format, meta):
+  if key == 'CodeBlock':
+    [[ident, classes, keyvals], code] = value
+    #sys.stderr.write(str(classes))
+    if "ignore" in classes:
+      return Null()
+    return CodeBlock([ident, classes, keyvals], code)
+
+if __name__ == "__main__":
+  toJSONFilter(ignore)


### PR DESCRIPTION
We also need to adapt the github workflow to use plain pandoc:
```
for f in *.rst do
  pandoc -o $f.ipynb $f --filter ../pandoc_filters/filter1.py --filter ../pandoc_filters/filter2.py
done
```
maybe we can wildcard filters as well.