### PR TITLE
Feat/pandocconversion

### DIFF
--- a/docs/pandoc_filters/transformlinks_pandocfilter.py
+++ b/docs/pandoc_filters/transformlinks_pandocfilter.py
@@ -13,10 +13,7 @@ def transformLink(key, value, _, meta):
         [ident, classes, keyvals], alttext, [dest, typef] = value
         link, sep, rest = dest.partition("#")  # for anchors
         # TODO better checks? use urllib?
-        if not (link.startswith("http://") or
-              link.startswith("https://") or
-              link.startswith("ftp://")) and
-              link.endswith(".html"):
+        if not (link.startswith("http://") or link.startswith("https://") or link.startswith("ftp://")) and link.endswith(".html"):
             link = link.replace(".html", ".ipynb")
             dest = link + sep + rest
         return Link([ident, classes, keyvals], alttext, [dest, typef])


### PR DESCRIPTION
TODOS:

- [x] linting
- [ ] We also need to adapt the github workflow to use plain pandoc:
```
for f in *.rst do
  pandoc -o $f.ipynb $f --filter ../pandoc_filters/filter1.py --filter ../pandoc_filters/filter2.py
done
```
maybe we can wildcard filters as well.

- [ ] Modify the ignoring filter to consider also other types of "Nodes" we need, e.g. Header, ~~Image~~, Link
- [ ] Change all display of "outputs" to `.. code-block: console` instead of `.. code-block: python`
- [x] Add a filter to replace HTML with ipynb in links
- [ ] Add ":class: ignore" to ALL the binder images and everything else we want to ignore in Binder
- [ ] Make all links fit the actual header for anchoring: e.g. PeptideIdentification instead of peptideidentification