### PR TITLE
updated supported versions in install instructions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -53,7 +53,7 @@ can type
 We have binary packages for OSX, Linux and Windows (64 bit only) available from
 `PyPI <https://pypi.org/project/pyopenms>`_. Make sure to download
 the 64bit Python release for Windows. Currently we only support
-Python 3.6, 3.7, 3.8 and 3.9.
+Python 3.7, 3.8 and 3.9.
 
 You can install Python first from `here <https://www.python.org/downloads/>`_,
 again make sure to download the 64bit release. You can then open a shell and

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -51,10 +51,9 @@ can type
 
 
 We have binary packages for OSX, Linux and Windows (64 bit only) available from
-`PyPI <https://pypi.org/project/pyopenms>`_. Note that for Windows, we only
-support Python 3.5, 3.6 and 3.7 in their 64 bit versions, therefore make sure
-to download the 64bit Python release for Windows. For OSX and Linux, we
-additionally also support Python 2.7 as well as Python 3.4 (Linux only).
+`PyPI <https://pypi.org/project/pyopenms>`_. Make sure to download
+the 64bit Python release for Windows. Currently we only support
+Python 3.6, 3.7, 3.8 and 3.9.
 
 You can install Python first from `here <https://www.python.org/downloads/>`_,
 again make sure to download the 64bit release. You can then open a shell and


### PR DESCRIPTION
at the mentioned PyPI link, wheels for python versions cp37, cp38 and cp39 are available for all platforms.